### PR TITLE
Fixed a typo

### DIFF
--- a/MiningProfitability.ipynb
+++ b/MiningProfitability.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "Motivation\n",
     "------------\n",
-    "As outlined in Satoshi's whitepaper [Bitcoin: A Peer-to-Peer Electronic Cash System], a network of timeptamp servers secures the Bitcoin blockchain by calculating a hash for each block header. A healthy Biticoin \"minining\" sector is necessary for the future of Bitcoin and cryptocurrencies which use \"proof of work\" to safeguard distributed ledgers against double spending. \n",
+    "As outlined in Satoshi's whitepaper [Bitcoin: A Peer-to-Peer Electronic Cash System], a network of timestamp servers secures the Bitcoin blockchain by calculating a hash for each block header. A healthy Biticoin \"minining\" sector is necessary for the future of Bitcoin and cryptocurrencies which use \"proof of work\" to safeguard distributed ledgers against double spending. \n",
     "\n",
     "The objective of this analysis is to construct a Bitcoin mining profitability model which can help prospective or exisiting Bitcoin miners plan capacity. By removing some of the uncertainty from miners' investment decisions, we hope to lower risk of investment, encourage comptetition and drive Bitcoin mining towards becoming a reliable and reputable utility underpinning a healthy cryptocurrency ecosystem. \n",
     "\n",


### PR DESCRIPTION
I found it slightly confusing that the "plot of the profit function" is not a plot of the function defined by:

![image](https://cloud.githubusercontent.com/assets/943039/9792628/a83d9084-57d0-11e5-8694-e079ef975bbb.png)

but a plot of its components. Maybe a different wording would eliminate the confusion.

A feature request: Scenario analysis with B and S as variables :)
